### PR TITLE
Add missing krb5 dependency for Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ test:
 
 about:
   home: https://www.psycopg.org/
-  license: LGPL, BSD-like, ZPL
+  license: LGPL-3.0-or-later AND Other
   license_family: LGPL
   license_file: LICENSE
   summary: PostgreSQL database adapter for Python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
     - psycopg2._psycopg
 
 about:
-  home: http://initd.org/psycopg/
+  home: https://www.psycopg.org/
   license: LGPL, BSD-like, ZPL
   license_family: LGPL
   license_file: LICENSE
@@ -47,7 +47,7 @@ about:
     Psycopg is the most popular PostgreSQL adapter for the Python programming
     language. Its main features are the complete implementation of the Python DB
     API 2.0 specification and the thread safety.
-  doc_url: http://initd.org/psycopg/docs/
+  doc_url: https://www.psycopg.org/docs/
   doc_source_url: https://github.com/psycopg/psycopg2/blob/master/doc/src/index.rst
   dev_url: https://github.com/psycopg/psycopg2/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
   run:
     - python
     - libpq
+    - krb5  # [win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
     # - 0001-fix-library-names-for-openssl-1.1.1-on-win.patch
 
 build:
-  number: 1
+  number: 2
   ignore_run_exports:
     - openssl
+    - krb5  # [win]
 
 requirements:
   build:
@@ -26,6 +27,7 @@ requirements:
     - pip
     - openssl
     - postgresql
+    - krb5  # [win]
   run:
     - python
     - libpq


### PR DESCRIPTION
### Changes

Added `krb5` dependency for Windows
Updated `home` and `doc_url`

### Notes

`psycopg2` cannot be successfully imported without the `krb5` dependency. This package may have been built previously on a system that already had `gssapi64.dll` available, but Prefect (and the dev instances) do not.

This issue was preventing `aiopg` from being tested on Windows. This update may also re-enable Windows testing for `django`.