### PR TITLE
Rebuild against postgresql v17

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,3 @@ build_parameters:
   - "--suppress-variables"
   - "--skip-existing"
   - "--error-overlinking"
-  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [py<37]
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -24,10 +24,10 @@ requirements:
     - pip
     - wheel
     - setuptools
-    - libpq 12.15
+    - libpq 17.0
   run:
     - python
-    - libpq
+    - libpq  # Version pinned from libpq run_exports.
 
 test:
   imports:


### PR DESCRIPTION
psycopg2 2.9.9 b1

**Destination channel:** defaults

### Links

- [PKG-6106](https://anaconda.atlassian.net/browse/PKG-6106)
- [Upstream repository](https://github.com/psycopg/psycopg2/tree/2.9.9)
- Relevant dependency PRs:
  - AnacondaRecipes/postgresql-feedstock#10


### Explanation of changes:

- `--error-overdepending` catches `vs2015_runtime` on Windows

[PKG-6106]: https://anaconda.atlassian.net/browse/PKG-6106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ