### PR TITLE
psycopg2 2.9.10

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,5 @@ build_parameters:
   - "--suppress-variables"
   - "--skip-existing"
   - "--error-overlinking"
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,5 +2,3 @@ build_parameters:
   - "--suppress-variables"
   - "--skip-existing"
   - "--error-overlinking"
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,6 @@ test:
   imports:
     - psycopg2
     - psycopg2._psycopg
-    - 
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ test:
     - psycopg2._psycopg
   commands:
     - pip check
+    - $(PYTHON) -c "import tests; tests.unittest.main(defaultTest='tests.test_suite')" --verbose
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.9.9" %}
+{% set version = "2.9.10" %}
 
 package:
   name: psycopg2
@@ -6,13 +6,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/psycopg2/psycopg2-{{ version }}.tar.gz
-  sha256: d1454bde93fb1e224166811694d600e746430c006fbb031ea06ecc2ea41bf156
-  patches:
-    - have_openssl.patch
+  sha256: 12ec0b40b0273f95296233e8750441339298e6a572f7039da5b260e3c8b60e11
+  # patches:
+  #   - have_openssl.patch
 
 build:
-  skip: true  # [py<37]
-  number: 1
+  skip: true  # [py<38]
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
   imports:
     - psycopg2
     - psycopg2._psycopg
+    - 
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,8 @@ package:
 source:
   url: https://pypi.io/packages/source/p/psycopg2/psycopg2-{{ version }}.tar.gz
   sha256: 12ec0b40b0273f95296233e8750441339298e6a572f7039da5b260e3c8b60e11
-  # patches:
-  #   - have_openssl.patch
+  patches:
+    - have_openssl.patch
 
 build:
   skip: true  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,14 +30,20 @@ requirements:
     - libpq  # Version pinned from libpq run_exports.
 
 test:
+  source_files:
+    - tests
   imports:
     - psycopg2
     - psycopg2._psycopg
   commands:
     - pip check
-    - $(PYTHON) -c "import tests; tests.unittest.main(defaultTest='tests.test_suite')" --verbose
+    # Run only aggregator test suites to avoid failures from tests requiring a live PostgreSQL server.
+    # Upstream tests assume a running PostgreSQL instance on localhost, which is not available in CI.
+    - pytest tests -v -k "test_suite"
   requires:
     - pip
+    - pytest
+    - postgresql
 
 about:
   home: https://www.psycopg.org/


### PR DESCRIPTION
> ## ☆ psycopg2 2.9.10 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-7870) 
[Upstream](https://github.com/psycopg/psycopg2/tree/2.9.10)
> 
> ### Changes
> * Updated version number and sha256
> * Added skip to python versions less than 3.8